### PR TITLE
Swapping blacfriday markup handler for goldmark

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -75,8 +75,8 @@ url = "https://www.appmeshworkshop.com/"
 weight = 23
 
 [markup]
-  defaultMarkdownHandler = "blackfriday"
-  [markup.blackFriday]
+  defaultMarkdownHandler = "goldmark"
+  [markup.goldmark]
     hrefTargetBlank = true
 
 [Languages] # Modify to change the language/version settings and/or version secondary extensions


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When cloning this repo and running `hugo server` with `hugo v0.106.0+extended darwin/amd64 BuildDate=unknown` I'm getting

```
Error: add site dependencies: create deps: markup: Configured defaultMarkdownHandler "blackfriday" not found. Did you mean to use goldmark? Blackfriday was removed in Hugo v0.100.0.
```

I'm assuming what I did fixes that, but I'm no Hugo expert. I suggest @Folrig take a look at this? Would be happy to modify as needed with some guidance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
