### PR TITLE
Updating Pipeline.yaml and cloudfront-s3-website.yaml Files

### DIFF
--- a/pipeline/webhosting/cloudfront-s3-website.yaml
+++ b/pipeline/webhosting/cloudfront-s3-website.yaml
@@ -3,7 +3,7 @@ Description: Creates an S3 bucket and CloudFront Distribution using Origins Acce
 Parameters:
   WorkshopHostname:
     Type: String
-    Default: xxxxxxxx
+    Default: xxxxxxx
     Description: The hostname of the workshop
     AllowedPattern: (?!-)[a-zA-Z0-9-.]{1,20}(?<!-)
     ConstraintDescription: must be a valid DNS name.

--- a/pipeline/webhosting/cloudfront-s3-website.yaml
+++ b/pipeline/webhosting/cloudfront-s3-website.yaml
@@ -83,7 +83,7 @@ Resources:
           S3OriginConfig:
             OriginAccessIdentity: !Join ["", ["origin-access-identity/cloudfront/", !Ref OriginAccessID]]
         ViewerCertificate:
-          AcmCertificateArn: '{{resolve:secretsmanager:Cloudfront-Distribution-Cert:SecretString}}'
+          AcmCertificateArn: '{{resolve:secretsmanager:CloudFront-Distribution-Cert:SecretString}}'
           SslSupportMethod: sni-only  
         Logging: 
           Bucket: "access-logs-modernization-workshops.s3.amazonaws.com"

--- a/pipeline/webhosting/cloudfront-s3-website.yaml
+++ b/pipeline/webhosting/cloudfront-s3-website.yaml
@@ -3,7 +3,7 @@ Description: Creates an S3 bucket and CloudFront Distribution using Origins Acce
 Parameters:
   WorkshopHostname:
     Type: String
-    Default: xxxxxxx
+    Default: my-project
     Description: The hostname of the workshop
     AllowedPattern: (?!-)[a-zA-Z0-9-.]{1,20}(?<!-)
     ConstraintDescription: must be a valid DNS name.

--- a/pipeline/webhosting/cloudfront-s3-website.yaml
+++ b/pipeline/webhosting/cloudfront-s3-website.yaml
@@ -13,11 +13,6 @@ Parameters:
     Description: The DNS name of an existing Amazon Route 53 hosted zone 
     AllowedPattern: (?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
     ConstraintDescription: must be a valid DNS zone name.
-  CertificateArn:
-    Type: String
-    Default:  arn:aws:acm:us-east-1:497025854095:certificate/491991ad-c0b4-4793-98a1-dee54cc3a095
-    Description: ARN of a certificate in us-east-1 as its needed for a CloudFront Distribution
-    AllowedPattern: "arn:aws:acm:.*"
   OriginAccessID:
     Type: String
     Default: E23ZJHO0JEB5ON
@@ -88,7 +83,7 @@ Resources:
           S3OriginConfig:
             OriginAccessIdentity: !Join ["", ["origin-access-identity/cloudfront/", !Ref OriginAccessID]]
         ViewerCertificate:
-          AcmCertificateArn: !Ref CertificateArn
+          AcmCertificateArn: '{{resolve:secretsmanager:Cloudfront-Distribution-Cert:SecretString}}'
           SslSupportMethod: sni-only  
         Logging: 
           Bucket: "access-logs-modernization-workshops.s3.amazonaws.com"

--- a/pipeline/webhosting/cloudfront-s3-website.yaml
+++ b/pipeline/webhosting/cloudfront-s3-website.yaml
@@ -3,7 +3,7 @@ Description: Creates an S3 bucket and CloudFront Distribution using Origins Acce
 Parameters:
   WorkshopHostname:
     Type: String
-    Default: my-project
+    Default: xxxxxx
     Description: The hostname of the workshop
     AllowedPattern: (?!-)[a-zA-Z0-9-.]{1,20}(?<!-)
     ConstraintDescription: must be a valid DNS name.

--- a/pipeline/webhosting/pipeline.yaml
+++ b/pipeline/webhosting/pipeline.yaml
@@ -27,7 +27,7 @@ Parameters:
   FullRepoURL:
     Type: String
     Description: The full url to the repo
-    Default: https://github.com/aws-samples/aws-modernization-with-  
+    Default: https://github.com/aws-samples/aws-modernization-with-
   GitHubOwner:
     Type: String
     Description: GitHub owner name

--- a/pipeline/webhosting/pipeline.yaml
+++ b/pipeline/webhosting/pipeline.yaml
@@ -1,92 +1,222 @@
-#!/bin/bash
+AWSTemplateFormatVersion: "2010-09-09"
+Description: This template will launch the Modernization Workshop CI/CD Pipeline.
 
-echo "Please ensure you have set up the temporary credentials from the apn-modern-workshop-group Isengard account in your command terminal."
+# It should only be necessary to update the parameters
+# run this stack as below but sub for {WORKSHOP NAME} with the workshop/company name and set the value
+# of CloudFrontDistroId resulting from the S3 + CloudFront CloudFormation template.
 
-cd aws-modernization-with-snyk-sentinelone/pipeline/webhosting/
-# Prompt the user to verify they are in the correct directory
-echo "Ensure you are in the correct directory within the new repository where the CloudFormation templates are located."
-read -p "Press Enter to continue if you are in the correct directory, or Ctrl+C to abort and navigate to the correct directory..."
+# aws cloudformation create-stack --stack-name {WORKSHOP NAME}-Website-Pipeline --template-body file://pipeline.yaml --capabilities CAPABILITY_NAMED_IAM
 
-# Automatically set the AWS region
-export AWS_REGION=us-west-2
-echo "AWS region set to $AWS_REGION."
+Parameters:
+  ProjectName:
+    Type: String
+    Description: Project Name
+    Default: xxxxxx
+  WebsiteBucket:
+    Type: String
+    Description: Website S3 bucket name
+    Default: xxxxxx.awsworkshop.io
+  CloudFrontDistroId:
+    Type: String
+    Description: CloudFront distribution ID 
+    Default: E129K8O9UGD45B
+  GitHubRepo:
+    Type: String
+    Description: repo name
+    Default: aws-modernization-with-xxxxxx
+  FullRepoURL:
+    Type: String
+    Description: The full url to the repo
+    Default: https://github.com/aws-samples/aws-modernization-with-xxxxxx
+  GitHubOwner:
+    Type: String
+    Description: GitHub owner name
+    Default: aws-samples
+  
+Resources:
+  CodeBuildServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CodeBuildService
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Resource: 
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${ProjectName}-Workshop-website*'
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+              - Resource: !Sub arn:aws:s3:::${ArtifactBucket}/*
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:GetObjectVersion
+              - Resource: 
+                  - !Sub arn:aws:s3:::${WebsiteBucket}/*
+                  - !Sub arn:aws:s3:::${WebsiteBucket}
+                Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:GetObjectVersion
+                  - s3:ListBucket
+                  - S3:DeleteObject
+                  - S3:DeleteObjectVersion
+              - Effect: Allow
+                Action:
+                  - cloudfront:CreateInvalidation
+                Resource: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistroId}
 
-# Step 1: Get the workshop hostname and inform about the URL naming
-echo "The name you enter for the workshop hostname will form the URL of the workshop."
-echo "For example, entering 'my-workshop' will create the URL 'my-workshop.awsworkshop.io'."
-read -p "Enter your workshop hostname (1-20 characters, no uppercase): " workshop_hostname
+  CodePipelineServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CodePipelineService
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Resource:
+                  - !Sub arn:aws:s3:::${ArtifactBucket}/*
+                Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:GetBucketVersioning
+              - Resource: 
+                  - !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${ProjectName}-Workshop-website'
+                Effect: Allow
+                Action:
+                  - codebuild:StartBuild
+                  - codebuild:BatchGetBuilds
 
-# Validate hostname length and character set
-if [[ ! "$workshop_hostname" =~ ^[a-z0-9-]{1,20}$ ]] || [[ "$workshop_hostname" =~ ^-.* ]] || [[ "$workshop_hostname" =~ .*$- ]]; then
-    echo "Hostname must be 1-20 lowercase alphanumeric characters, may contain hyphens but not start or end with them."
-    exit 1
-fi
+  ArtifactBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    Properties:
+      VersioningConfiguration:
+        Status: Enabled 
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: 'AES256'
 
-# Replace the WorkshopHostname in the cloudfront-s3-website.yaml file
-sed -i '' "s/xxxxxxxx/$workshop_hostname/g" cloudfront-s3-website.yaml || { echo "Error updating cloudfront-s3-website.yaml."; exit 1; }
+  ArtifactBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref 'ArtifactBucket'
+      PolicyDocument:
+        Statement:
+        - Action: 's3:*'  
+          Effect: Deny
+          Resource: 
+            - !Join ['', ['arn:aws:s3:::', !Ref 'ArtifactBucket', /*]]
+            - !Join ['', ['arn:aws:s3:::', !Ref 'ArtifactBucket']]
+          Principal: '*'
+          Condition:
+            Bool:
+              aws:SecureTransport: false
 
-# Set the stack name for CloudFront and S3 based on the workshop hostname
-cloudfront_stack_name="${workshop_hostname}-Workshop"
+  CodeBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: webspec.yml
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:2.0
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: AWS_DEFAULT_REGION
+            Value: !Ref AWS::Region
+          - Name: FULL_REPO_URL
+            Value: !Ref FullRepoURL
+          - Name: WEB_SITE_BUCKET
+            Value: !Ref WebsiteBucket
+          - Name: CLOUDFRONT_DISTRO_ID
+            Value: !Ref CloudFrontDistroId
+        PrivilegedMode: true
+      Name: !Join ['', [!Ref 'ProjectName', '-Workshop-website']]
+      ServiceRole: !Ref CodeBuildServiceRole
+                     
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      RoleArn: !GetAtt CodePipelineServiceRole.Arn
+      ArtifactStore:
+        Type: S3
+        Location: !Ref ArtifactBucket
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: Source
+              ActionTypeId:
+                Category: Source
+                Owner: ThirdParty
+                Version: '1'
+                Provider: GitHub
+              Configuration:
+                Owner: !Ref GitHubOwner
+                Repo: !Ref GitHubRepo
+                Branch: main
+                PollForSourceChanges: false
+                OAuthToken: '{{resolve:secretsmanager:GitHub/WorkshopOwnerToken:SecretString:OwnerToken}}'
+              OutputArtifacts:
+                - Name: SourceCode
+              RunOrder: 1
+        - Name: Build
+          Actions:
+            - Name: Build
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: '1'
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref CodeBuildProject
+              InputArtifacts:
+                - Name: SourceCode
+              OutputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 1
+    
+  GithubWebhook:
+    Type: 'AWS::CodePipeline::Webhook'
+    Properties:
+      Authentication: GITHUB_HMAC
+      AuthenticationConfiguration:
+        SecretToken: '{{resolve:secretsmanager:GitHub/WorkshopOwnerToken:SecretString:OwnerToken}}'
+      RegisterWithThirdParty: true
+      Filters:
+      - JsonPath: "$.ref"
+        MatchEquals: refs/heads/{Branch}
+      TargetPipeline: !Ref Pipeline
+      TargetAction: Source
+      TargetPipelineVersion: !GetAtt Pipeline.Version
 
-echo "Creating CloudFront and S3 stack with name $cloudfront_stack_name..."
-if ! aws cloudformation create-stack --stack-name "$cloudfront_stack_name" --template-body file://cloudfront-s3-website.yaml --enable-termination-protection; then
-    echo "Error creating CloudFront and S3 stack."
-    exit 1
-fi
-
-# Check the status of the CloudFormation stack until it is complete or has failed
-echo "Checking the status of the stack. This may take a few minutes..."
-while :; do
-    stack_status=$(aws cloudformation describe-stacks --stack-name "$cloudfront_stack_name" --query "Stacks[0].StackStatus" --output text)
-    if [[ $stack_status == "CREATE_COMPLETE" ]]; then
-        echo "Stack $cloudfront_stack_name has been created successfully."
-        break
-    elif [[ $stack_status == "CREATE_FAILED" ]]; then
-        echo "Stack creation failed for $cloudfront_stack_name."
-        exit 1
-    else
-        echo "Current status of $cloudfront_stack_name: $stack_status"
-        sleep 30
-    fi
-done
-
-# Step 2: Retrieve the CloudFront Distribution ID
-echo "Retrieving CloudFront Distribution ID..."
-distribution_id=$(aws cloudformation describe-stacks --stack-name "$cloudfront_stack_name" --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistroId'].OutputValue" --output text) || { echo "Error retrieving CloudFront Distribution ID."; exit 1; }
-
-echo "CloudFront Distribution ID: $distribution_id"
-
-# Step 3: Modify pipeline.yaml and create the CodePipeline stack
-# Update the pipeline.yaml file with the necessary parameters
-sed -i '' "s/xxxxxxxx/$workshop_hostname/g" pipeline.yaml || { echo "Error updating pipeline.yaml."; exit 1; }
-sed -i '' "s/xxxxxxxx.awsworkshop.io/$workshop_hostname.awsworkshop.io/g" pipeline.yaml || { echo "Error updating pipeline.yaml."; exit 1; }
-sed -i '' "s/xxx/$distribution_id/g" pipeline.yaml || { echo "Error updating pipeline.yaml."; exit 1; }
-sed -i '' "s/aws-modernization-with-$/aws-modernization-with-$workshop_hostname/g" pipeline.yaml || { echo "Error updating pipeline.yaml."; exit 1; }
-sed -i '' "s|https://github.com/aws-samples/aws-modernization-with-|https://github.com/aws-samples/aws-modernization-with-$workshop_hostname.git|g" pipeline.yaml || { echo "Error updating pipeline.yaml."; exit 1; }
-
-# Set the stack name for the pipeline based on the workshop hostname
-pipeline_stack_name="${workshop_hostname}-Pipeline"
-
-echo "Creating CodePipeline stack with name $pipeline_stack_name..."
-if ! aws cloudformation create-stack --stack-name "$pipeline_stack_name" --template-body file://pipeline.yaml --capabilities CAPABILITY_NAMED_IAM --enable-termination-protection; then
-    echo "Error creating CodePipeline stack."
-    exit 1
-fi
-
-# Check the status of the CloudFormation stack until it is complete or has failed
-echo "Checking the status of the stack. This can take up to 20 minutes for the website to become available..."
-while :; do
-    stack_status=$(aws cloudformation describe-stacks --stack-name "$pipeline_stack_name" --query "Stacks[0].StackStatus" --output text)
-    if [[ $stack_status == "CREATE_COMPLETE" ]]; then
-        echo "Stack $pipeline_stack_name has been created successfully."
-        break
-    elif [[ $stack_status == "CREATE_FAILED" ]]; then
-        echo "Stack creation failed for $pipeline_stack_name."
-        exit 1
-    else
-        echo "Current status of $pipeline_stack_name: $stack_status"
-        sleep 30
-    fi
-done
-
-echo "Setup complete. Check the CloudFront distribution full domain in the AWS Management Console."
+Outputs:
+  PipelineUrl:
+    Value: !Sub https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${Pipeline}  

--- a/pipeline/webhosting/pipeline.yaml
+++ b/pipeline/webhosting/pipeline.yaml
@@ -19,11 +19,11 @@ Parameters:
   CloudFrontDistroId:
     Type: String
     Description: CloudFront distribution ID 
-    Default: xxxxxxxx
+    Default: xxx
   GitHubRepo:
     Type: String
     Description: repo name
-    Default: aws-modernization-xxxxxxx
+    Default: aws-modernization-with-
   FullRepoURL:
     Type: String
     Description: The full url to the repo
@@ -219,4 +219,4 @@ Resources:
 
 Outputs:
   PipelineUrl:
-    Value: !Sub https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${Pipeline}      
+    Value: !Sub https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${Pipeline}

--- a/pipeline/webhosting/pipeline.yaml
+++ b/pipeline/webhosting/pipeline.yaml
@@ -27,11 +27,11 @@ Parameters:
   FullRepoURL:
     Type: String
     Description: The full url to the repo
-    Default: https://github.com/aws-samples/aws-modernization-xxxxxxxx.git  
+    Default: https://github.com/aws-samples/aws-modernization-with-  
   GitHubOwner:
     Type: String
     Description: GitHub owner name
-    Default: aws-samples  
+    Default: aws-samples
   
 Resources:
   CodeBuildServiceRole:
@@ -219,4 +219,4 @@ Resources:
 
 Outputs:
   PipelineUrl:
-    Value: !Sub https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${Pipeline}
+    Value: !Sub https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${Pipeline}      

--- a/pipeline/webhosting/pipeline.yaml
+++ b/pipeline/webhosting/pipeline.yaml
@@ -19,7 +19,7 @@ Parameters:
   CloudFrontDistroId:
     Type: String
     Description: CloudFront distribution ID
-    Default: xxx
+    Default: XXX
   GitHubRepo:
     Type: String
     Description: repo name

--- a/pipeline/webhosting/pipeline.yaml
+++ b/pipeline/webhosting/pipeline.yaml
@@ -27,7 +27,7 @@ Parameters:
   FullRepoURL:
     Type: String
     Description: The full url to the repo
-    Default: https://github.com/aws-samples/aws-modernization-with-xxxxxx
+    Default: https://github.com/aws-samples/aws-modernization-with-xxxxxx.git
   GitHubOwner:
     Type: String
     Description: GitHub owner name

--- a/pipeline/webhosting/pipeline.yaml
+++ b/pipeline/webhosting/pipeline.yaml
@@ -1,222 +1,92 @@
-AWSTemplateFormatVersion: "2010-09-09"
-Description: This template will launch the Modernization Workshop CI/CD Pipeline.
+#!/bin/bash
 
-# It should only be necessary to update the parameters
-# run this stack as below but sub for {WORKSHOP NAME} with the workshop/company name and set the value
-# of CloudFrontDistroId resulting from the S3 + CloudFront CloudFormation template.
+echo "Please ensure you have set up the temporary credentials from the apn-modern-workshop-group Isengard account in your command terminal."
 
-# aws cloudformation create-stack --stack-name {WORKSHOP NAME}-Website-Pipeline --template-body file://pipeline.yaml --capabilities CAPABILITY_NAMED_IAM
+cd aws-modernization-with-snyk-sentinelone/pipeline/webhosting/
+# Prompt the user to verify they are in the correct directory
+echo "Ensure you are in the correct directory within the new repository where the CloudFormation templates are located."
+read -p "Press Enter to continue if you are in the correct directory, or Ctrl+C to abort and navigate to the correct directory..."
 
-Parameters:
-  ProjectName:
-    Type: String
-    Description: Project Name
-    Default: xxxxxxxx
-  WebsiteBucket:
-    Type: String
-    Description: Website S3 bucket name
-    Default: xxxxxxxx.awsworkshop.io 
-  CloudFrontDistroId:
-    Type: String
-    Description: CloudFront distribution ID 
-    Default: xxx
-  GitHubRepo:
-    Type: String
-    Description: repo name
-    Default: aws-modernization-with-
-  FullRepoURL:
-    Type: String
-    Description: The full url to the repo
-    Default: https://github.com/aws-samples/aws-modernization-with-
-  GitHubOwner:
-    Type: String
-    Description: GitHub owner name
-    Default: aws-samples
-  
-Resources:
-  CodeBuildServiceRole:
-    Type: AWS::IAM::Role
-    Properties:
-      Path: /
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: codebuild.amazonaws.com
-            Action: sts:AssumeRole
-      Policies:
-        - PolicyName: CodeBuildService
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Resource: 
-                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${ProjectName}-Workshop-website*'
-                Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-              - Resource: !Sub arn:aws:s3:::${ArtifactBucket}/*
-                Effect: Allow
-                Action:
-                  - s3:GetObject
-                  - s3:PutObject
-                  - s3:GetObjectVersion
-              - Resource: 
-                  - !Sub arn:aws:s3:::${WebsiteBucket}/*
-                  - !Sub arn:aws:s3:::${WebsiteBucket}
-                Effect: Allow
-                Action:
-                  - s3:GetObject
-                  - s3:PutObject
-                  - s3:GetObjectVersion
-                  - s3:ListBucket
-                  - S3:DeleteObject
-                  - S3:DeleteObjectVersion
-              - Effect: Allow
-                Action:
-                  - cloudfront:CreateInvalidation
-                Resource: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistroId}
+# Automatically set the AWS region
+export AWS_REGION=us-west-2
+echo "AWS region set to $AWS_REGION."
 
-  CodePipelineServiceRole:
-    Type: AWS::IAM::Role
-    Properties:
-      Path: /
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: codepipeline.amazonaws.com
-            Action: sts:AssumeRole
-      Policies:
-        - PolicyName: CodePipelineService
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Resource:
-                  - !Sub arn:aws:s3:::${ArtifactBucket}/*
-                Effect: Allow
-                Action:
-                  - s3:PutObject
-                  - s3:GetObject
-                  - s3:GetObjectVersion
-                  - s3:GetBucketVersioning
-              - Resource: 
-                  - !Sub 'arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${ProjectName}-Workshop-website'
-                Effect: Allow
-                Action:
-                  - codebuild:StartBuild
-                  - codebuild:BatchGetBuilds
+# Step 1: Get the workshop hostname and inform about the URL naming
+echo "The name you enter for the workshop hostname will form the URL of the workshop."
+echo "For example, entering 'my-workshop' will create the URL 'my-workshop.awsworkshop.io'."
+read -p "Enter your workshop hostname (1-20 characters, no uppercase): " workshop_hostname
 
-  ArtifactBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Delete
-    Properties:
-      VersioningConfiguration:
-        Status: Enabled 
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: 'AES256'
+# Validate hostname length and character set
+if [[ ! "$workshop_hostname" =~ ^[a-z0-9-]{1,20}$ ]] || [[ "$workshop_hostname" =~ ^-.* ]] || [[ "$workshop_hostname" =~ .*$- ]]; then
+    echo "Hostname must be 1-20 lowercase alphanumeric characters, may contain hyphens but not start or end with them."
+    exit 1
+fi
 
-  ArtifactBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref 'ArtifactBucket'
-      PolicyDocument:
-        Statement:
-        - Action: 's3:*'  
-          Effect: Deny
-          Resource: 
-            - !Join ['', ['arn:aws:s3:::', !Ref 'ArtifactBucket', /*]]
-            - !Join ['', ['arn:aws:s3:::', !Ref 'ArtifactBucket']]
-          Principal: '*'
-          Condition:
-            Bool:
-              aws:SecureTransport: false
+# Replace the WorkshopHostname in the cloudfront-s3-website.yaml file
+sed -i '' "s/xxxxxxxx/$workshop_hostname/g" cloudfront-s3-website.yaml || { echo "Error updating cloudfront-s3-website.yaml."; exit 1; }
 
-  CodeBuildProject:
-    Type: AWS::CodeBuild::Project
-    Properties:
-      Artifacts:
-        Type: CODEPIPELINE
-      Source:
-        Type: CODEPIPELINE
-        BuildSpec: webspec.yml
-      Environment:
-        ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:2.0
-        Type: LINUX_CONTAINER
-        EnvironmentVariables:
-          - Name: AWS_DEFAULT_REGION
-            Value: !Ref AWS::Region
-          - Name: FULL_REPO_URL
-            Value: !Ref FullRepoURL
-          - Name: WEB_SITE_BUCKET
-            Value: !Ref WebsiteBucket
-          - Name: CLOUDFRONT_DISTRO_ID
-            Value: !Ref CloudFrontDistroId
-        PrivilegedMode: true
-      Name: !Join ['', [!Ref 'ProjectName', '-Workshop-website']]
-      ServiceRole: !Ref CodeBuildServiceRole
-                     
-  Pipeline:
-    Type: AWS::CodePipeline::Pipeline
-    Properties:
-      RoleArn: !GetAtt CodePipelineServiceRole.Arn
-      ArtifactStore:
-        Type: S3
-        Location: !Ref ArtifactBucket
-      Stages:
-        - Name: Source
-          Actions:
-            - Name: Source
-              ActionTypeId:
-                Category: Source
-                Owner: ThirdParty
-                Version: '1'
-                Provider: GitHub
-              Configuration:
-                Owner: !Ref GitHubOwner
-                Repo: !Ref GitHubRepo
-                Branch: main
-                PollForSourceChanges: false
-                OAuthToken: '{{resolve:secretsmanager:GitHub/WorkshopOwnerToken:SecretString:OwnerToken}}'
-              OutputArtifacts:
-                - Name: SourceCode
-              RunOrder: 1
-        - Name: Build
-          Actions:
-            - Name: Build
-              ActionTypeId:
-                Category: Build
-                Owner: AWS
-                Version: '1'
-                Provider: CodeBuild
-              Configuration:
-                ProjectName: !Ref CodeBuildProject
-              InputArtifacts:
-                - Name: SourceCode
-              OutputArtifacts:
-                - Name: BuildOutput
-              RunOrder: 1
-    
-  GithubWebhook:
-    Type: 'AWS::CodePipeline::Webhook'
-    Properties:
-      Authentication: GITHUB_HMAC
-      AuthenticationConfiguration:
-        SecretToken: '{{resolve:secretsmanager:GitHub/WorkshopOwnerToken:SecretString:OwnerToken}}'
-      RegisterWithThirdParty: true
-      Filters:
-      - JsonPath: "$.ref"
-        MatchEquals: refs/heads/{Branch}
-      TargetPipeline: !Ref Pipeline
-      TargetAction: Source
-      TargetPipelineVersion: !GetAtt Pipeline.Version
+# Set the stack name for CloudFront and S3 based on the workshop hostname
+cloudfront_stack_name="${workshop_hostname}-Workshop"
 
-Outputs:
-  PipelineUrl:
-    Value: !Sub https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${Pipeline}      
+echo "Creating CloudFront and S3 stack with name $cloudfront_stack_name..."
+if ! aws cloudformation create-stack --stack-name "$cloudfront_stack_name" --template-body file://cloudfront-s3-website.yaml --enable-termination-protection; then
+    echo "Error creating CloudFront and S3 stack."
+    exit 1
+fi
+
+# Check the status of the CloudFormation stack until it is complete or has failed
+echo "Checking the status of the stack. This may take a few minutes..."
+while :; do
+    stack_status=$(aws cloudformation describe-stacks --stack-name "$cloudfront_stack_name" --query "Stacks[0].StackStatus" --output text)
+    if [[ $stack_status == "CREATE_COMPLETE" ]]; then
+        echo "Stack $cloudfront_stack_name has been created successfully."
+        break
+    elif [[ $stack_status == "CREATE_FAILED" ]]; then
+        echo "Stack creation failed for $cloudfront_stack_name."
+        exit 1
+    else
+        echo "Current status of $cloudfront_stack_name: $stack_status"
+        sleep 30
+    fi
+done
+
+# Step 2: Retrieve the CloudFront Distribution ID
+echo "Retrieving CloudFront Distribution ID..."
+distribution_id=$(aws cloudformation describe-stacks --stack-name "$cloudfront_stack_name" --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistroId'].OutputValue" --output text) || { echo "Error retrieving CloudFront Distribution ID."; exit 1; }
+
+echo "CloudFront Distribution ID: $distribution_id"
+
+# Step 3: Modify pipeline.yaml and create the CodePipeline stack
+# Update the pipeline.yaml file with the necessary parameters
+sed -i '' "s/xxxxxxxx/$workshop_hostname/g" pipeline.yaml || { echo "Error updating pipeline.yaml."; exit 1; }
+sed -i '' "s/xxxxxxxx.awsworkshop.io/$workshop_hostname.awsworkshop.io/g" pipeline.yaml || { echo "Error updating pipeline.yaml."; exit 1; }
+sed -i '' "s/xxx/$distribution_id/g" pipeline.yaml || { echo "Error updating pipeline.yaml."; exit 1; }
+sed -i '' "s/aws-modernization-with-$/aws-modernization-with-$workshop_hostname/g" pipeline.yaml || { echo "Error updating pipeline.yaml."; exit 1; }
+sed -i '' "s|https://github.com/aws-samples/aws-modernization-with-|https://github.com/aws-samples/aws-modernization-with-$workshop_hostname.git|g" pipeline.yaml || { echo "Error updating pipeline.yaml."; exit 1; }
+
+# Set the stack name for the pipeline based on the workshop hostname
+pipeline_stack_name="${workshop_hostname}-Pipeline"
+
+echo "Creating CodePipeline stack with name $pipeline_stack_name..."
+if ! aws cloudformation create-stack --stack-name "$pipeline_stack_name" --template-body file://pipeline.yaml --capabilities CAPABILITY_NAMED_IAM --enable-termination-protection; then
+    echo "Error creating CodePipeline stack."
+    exit 1
+fi
+
+# Check the status of the CloudFormation stack until it is complete or has failed
+echo "Checking the status of the stack. This can take up to 20 minutes for the website to become available..."
+while :; do
+    stack_status=$(aws cloudformation describe-stacks --stack-name "$pipeline_stack_name" --query "Stacks[0].StackStatus" --output text)
+    if [[ $stack_status == "CREATE_COMPLETE" ]]; then
+        echo "Stack $pipeline_stack_name has been created successfully."
+        break
+    elif [[ $stack_status == "CREATE_FAILED" ]]; then
+        echo "Stack creation failed for $pipeline_stack_name."
+        exit 1
+    else
+        echo "Current status of $pipeline_stack_name: $stack_status"
+        sleep 30
+    fi
+done
+
+echo "Setup complete. Check the CloudFront distribution full domain in the AWS Management Console."

--- a/pipeline/webhosting/pipeline.yaml
+++ b/pipeline/webhosting/pipeline.yaml
@@ -18,8 +18,8 @@ Parameters:
     Default: xxxxxx.awsworkshop.io
   CloudFrontDistroId:
     Type: String
-    Description: CloudFront distribution ID 
-    Default: E129K8O9UGD45B
+    Description: CloudFront distribution ID
+    Default: xxx
   GitHubRepo:
     Type: String
     Description: repo name

--- a/webspec.yml
+++ b/webspec.yml
@@ -16,20 +16,20 @@ phases:
       - git remote add origin $FULL_REPO_URL
       - git fetch
       - git checkout -f "$CODEBUILD_RESOLVED_SOURCE_VERSION"
-      - git submodule init
-      - git submodule update --recursive
+      - echo "Initializing and updating Git submodules..."
+      - git submodule update --init --recursive
       - gem install asciidoctor
       - echo Install Hugo
-      - wget https://github.com/gohugoio/hugo/releases/download/v0.71.0/hugo_extended_0.71.0_Linux-64bit.tar.gz -O hugo_extended_0.71.0_Linux-64bit.tar.gz
-      - HUGO_TAR="$(find . -name "*Linux-64bit.tar.gz")"
-      - tar -xzf $HUGO_TAR
-      - chmod +x hugo
-
+      - wget https://github.com/gohugoio/hugo/releases/download/v0.71.0/hugo_extended_0.71.0_Linux-64bit.tar.gz
+      - tar -xzf hugo_extended_0.71.0_Linux-64bit.tar.gz
+      - mv hugo /usr/local/bin/hugo
+      - hugo version
   build:
     commands:
       - echo Build Website
-      - ./hugo -D -d public
+      - echo "Checking theme directory:"
+      - ls -al themes/
+      - hugo -D -d public
       - echo Deploy Copy Website to S3 Bucket
       - aws s3 sync public/ s3://${WEB_SITE_BUCKET}/ --delete
       - aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRO_ID} --paths /\*
-      

--- a/webspec.yml
+++ b/webspec.yml
@@ -28,6 +28,7 @@ phases:
     commands:
       - echo Build Website
       - echo "Checking theme directory:"
+      - pwd
       - ls -al themes/
       - hugo -D -d public
       - echo Deploy Copy Website to S3 Bucket

--- a/webspec.yml
+++ b/webspec.yml
@@ -29,7 +29,7 @@ phases:
       - echo Build Website
       - echo "Checking theme directory:"
       - pwd
-      - ls -al themes/
+      - ls -lar
       - hugo -D -d public
       - echo Deploy Copy Website to S3 Bucket
       - aws s3 sync public/ s3://${WEB_SITE_BUCKET}/ --delete


### PR DESCRIPTION
*Description of changes: git defender no longer allows any content that has any potential sensitive data. Since the ACM cert is hardcoded, we cannot follow the steps to deploy the base workshop content into any new repos. 

<img width="1175" alt="Screenshot 2024-03-28 at 10 49 36 AM" src="https://github.com/aws-samples/aws-modernization-workshop-base/assets/135752326/c3af219b-c278-4df9-84b0-ce8fad3a60d8">

To remedy this, I have added a secret that the CFT will pull once its executed.

<img width="687" alt="Screenshot 2024-03-28 at 1 52 55 PM" src="https://github.com/aws-samples/aws-modernization-workshop-base/assets/135752326/02e6f785-e093-4561-8c81-aa1a00d31b93">

I have also made slight adjustments to the placeholders in order to use sed to easily replace them with my automation script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
